### PR TITLE
Use get_home_url() instead of get_site_url()

### DIFF
--- a/src/Nunil_Base_Src_Rules.php
+++ b/src/Nunil_Base_Src_Rules.php
@@ -190,7 +190,7 @@ class Nunil_Base_Src_Rules {
 		$mode         = $this->get_nunil_external_host_mode_option();
 		$host_sources = array();
 
-		$local_site_url = get_site_url();
+		$local_site_url = get_home_url();
 		foreach ( $parsed_urls as $parsed_url ) {
 			$site_url = $parsed_url['scheme'] . '://' . $parsed_url['host'];
 


### PR DESCRIPTION
Prevents adding subdirectory to url (see: https://wordpress.stackexchange.com/questions/20294/whats-the-difference-between-home-url-and-site-url/324696#324696) 