### PR TITLE
Issue 19: new filter to modify not_sri_sources array

### DIFF
--- a/src/Nunil_Manipulate_DOM.php
+++ b/src/Nunil_Manipulate_DOM.php
@@ -924,6 +924,8 @@ class Nunil_Manipulate_DOM extends Nunil_Capture {
 			'cookie-cdn.cookiepro.com', // https://wordpress.org/support/topic/cookie-pro-script-gets-blocked-from-time-to-time/ .
 		);
 
+		$not_sri_sources = apply_filters( 'no_unsafe_inline_not_sri_sources', $not_sri_sources );
+
 		foreach ( $not_sri_sources as $source ) {
 			if ( false !== strpos( $sourcestr, $source ) ) {
 				// We found the not_sri_string in $sourcestr.


### PR DESCRIPTION
## Purpose
Currently three domains are in the `$not_sri_sources` array. These domains don't support integrity checking. Domains not in this list that do not have appropriately configured CORs headers will trigger an error like:

> Access to script at 'external resource URL' from origin 'wordpress-site-origin' has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the requested resource.

#### Issue Link
[Issue 19](https://github.com/MocioF/No-unsafe-inline/issues/19)

## Approach
Use the `apply_filters()` function to provide a hook to update this array.

For testing purposes, you can embed this script in a page:

`<script type="text/javascript" src="https://app.jazz.co/widgets/basic/create/olisystems" charset="utf-8"></script>`