### PR TITLE
fix Estimator has not been trained fatal error

### DIFF
--- a/src/Nunil_Manipulate_DOM.php
+++ b/src/Nunil_Manipulate_DOM.php
@@ -986,24 +986,29 @@ class Nunil_Manipulate_DOM extends Nunil_Capture {
 		$samples[] = $lsh_hex_digest;
 		$dataset   = new Unlabeled( $samples );
 
-		if ( is_null( $event ) && 'script' === $tagname && isset( $this->inline_scripts_classifier ) ) {
-			$predicted_labels = $this->inline_scripts_classifier->predict( $dataset );
-			$predicted_label  = $predicted_labels[0];
-			$list             = $this->inline_rows;
-		} elseif ( is_null( $event ) && 'script' !== $tagname && isset( $this->internal_css_classifier ) ) {
-			$predicted_labels = $this->internal_css_classifier->predict( $dataset );
-			$predicted_label  = $predicted_labels[0];
-			$list             = $this->inline_rows;
-		} elseif ( null !== $event && isset( $this->event_handlers_classifier ) ) {
-			$predicted_labels         = $this->event_handlers_classifier->predict( $dataset );
-			$combined_predicted_label = $predicted_labels[0];
-			$label_parts              = explode( '#', $combined_predicted_label, 2 );
-			$my_evh                   = $label_parts[0];
-			$predicted_label          = $label_parts[1];
-			$list                     = $this->events_rows;
-		} else {
+		try {
+			if ( is_null( $event ) && 'script' === $tagname && isset( $this->inline_scripts_classifier ) ) {
+				$predicted_labels = $this->inline_scripts_classifier->predict( $dataset );
+				$predicted_label  = $predicted_labels[0];
+				$list             = $this->inline_rows;
+			} elseif ( is_null( $event ) && 'script' !== $tagname && isset( $this->internal_css_classifier ) ) {
+				$predicted_labels = $this->internal_css_classifier->predict( $dataset );
+				$predicted_label  = $predicted_labels[0];
+				$list             = $this->inline_rows;
+			} elseif ( null !== $event && isset( $this->event_handlers_classifier ) ) {
+				$predicted_labels         = $this->event_handlers_classifier->predict( $dataset );
+				$combined_predicted_label = $predicted_labels[0];
+				$label_parts              = explode( '#', $combined_predicted_label, 2 );
+				$my_evh                   = $label_parts[0];
+				$predicted_label          = $label_parts[1];
+				$list                     = $this->events_rows;
+			} else {
+				return false;
+			}
+		} catch ( \Rubix\ML\Exceptions\RuntimeException $e ) {
 			return false;
 		}
+
 		if ( is_array( $list ) ) {
 			if ( 'Unclustered' !== $predicted_label ) {
 				if ( null === $event ) {


### PR DESCRIPTION
```
Fatal error: Uncaught Rubix\ML\Exceptions\RuntimeException: Estimator has not been trained. in /code/wp-content/plugins/no-unsafe-inline/vendor/rubix/ml/src/Classifiers/KNearestNeighbors.php:208 Stack trace: #0 /code/wp-content/plugins/no-unsafe-inline/src/Nunil_Manipulate_DOM.php(985): Rubix\ML\Classifiers\KNearestNeighbors->predict(Object(Rubix\ML\Datasets\Unlabeled)) #1 /code/wp-content/plugins/no-unsafe-inline/src/Nunil_Manipulate_DOM.php(416): NUNIL\Nunil_Manipulate_DOM->check_cluster_whitelist('11b84f029be7136...', 'script') #2 /code/wp-content/plugins/no-unsafe-inline/src/Nunil_Manipulate_DOM.php(302): NUNIL\Nunil_Manipulate_DOM->allow_inline(Object(DOMNodeList), 'script') #3 /code/wp-content/plugins/no-unsafe-inline/src/Nunil_Manipulate_DOM.php(273): NUNIL\Nunil_Manipulate_DOM->manipulate_inline_scripts() #4 /code/wp-content/plugins/no-unsafe-inline/public/class-no-unsafe-inline-public.php(210): NUNIL\Nunil_Manipulate_DOM->get_local_csp() #5 /code/wp-includes/class-wp-hook.php(324): No_Unsafe_Inline_Public->filter_final_output('...') #6 /code/wp-includes/plugin.php(205): WP_Hook->apply_filters('...', Array) #7 /code/wp-content/mu-plugins/no-unsafe-inline-output-buffering.php(100): apply_filters('no_unsafe_inlin...', '...') #8 /code/wp-includes/class-wp-hook.php(324): {closure}('') #9 /code/wp-includes/class-wp-hook.php(348): WP_Hook->apply_filters(NULL, Array) #10 /code/wp-includes/plugin.php(517): WP_Hook->do_action(Array) #11 /code/wp-includes/load.php(1304): do_action('shutdown') #12 [internal function]: shutdown_action_hook() #13 {main} thrown in /code/wp-content/plugins/no-unsafe-inline/vendor/rubix/ml/src/Classifiers/KNearestNeighbors.php on line 208 
```

This happens for me when cleaning the database, or enabling settings before tags.  This is a simple patch to just catch that exception to prevent fatal errors.

Also reported here:
https://wordpress.org/support/topic/fatal-error-uncaught-rubixmlexceptionsruntimeexception/